### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,4 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:
-          slug: anima-kit/searxng-docker
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
codecov upload failing because 'repo doesn't exist'; try without slug